### PR TITLE
Rename HOME_ERCF to ERCF_HOME for consistency

### DIFF
--- a/Klipper Macros/ercf_macros.cfg
+++ b/Klipper Macros/ercf_macros.cfg
@@ -222,7 +222,7 @@ variable_tool_selected: -1
 variable_color_selected: -1
 gcode:
     {% if printer["gcode_macro PAUSE_ERCF"].is_paused|int == 0 %}
-    	{% if printer["gcode_macro HOME_ERCF"].home != -1 %}
+    	{% if printer["gcode_macro ERCF_HOME"].home != -1 %}
         	M118 Select Tool {params.VALUE} ...
         	SERVO_UP
         	MANUAL_STEPPER STEPPER=selector_stepper MOVE={printer["gcode_macro VAR_ERCF"].colorselector[params.VALUE|int]} SPEED=100 ACCEL=200
@@ -239,7 +239,7 @@ gcode:
 [gcode_macro UNSELECT_TOOL]
 gcode:
     {% if printer["gcode_macro PAUSE_ERCF"].is_paused|int == 0 %}
-    	{% if printer["gcode_macro HOME_ERCF"].home != -1 %}
+    	{% if printer["gcode_macro ERCF_HOME"].home != -1 %}
     	    	SERVO_UP
         	SET_GCODE_VARIABLE MACRO=SELECT_TOOL VARIABLE=tool_selected VALUE=-1
     	{% else %}
@@ -663,27 +663,27 @@ gcode:
 
 ############################################
 # Homing macros
-# HOME_ERCF must be called before using the ERCF
+# ERCF_HOME must be called before using the ERCF
 ############################################
 
 # Home the ERCF
 # eject filament if loaded with EJECT_BEFORE_HOME
-# next home the ERCF with HOME_ERCF_ONLY
-[gcode_macro HOME_ERCF]
+# next home the ERCF with ERCF_HOME_ONLY
+[gcode_macro ERCF_HOME]
 variable_home: -1
 gcode:
     SET_FILAMENT_SENSOR SENSOR=toolhead_sensor ENABLE=0
-    SET_GCODE_VARIABLE MACRO=HOME_ERCF VARIABLE=home VALUE=1
+    SET_GCODE_VARIABLE MACRO=ERCF_HOME VARIABLE=home VALUE=1
     M118 Homing ERCF ...
     QUERY_ENDSTOPS
     EJECT_BEFORE_HOME
-    HOME_ERCF_ONLY
+    ERCF_HOME_ONLY
 
 # Home the ERCF:
 # 1) home the color selector (if needed)
 # 2) try to load filament 0 to ERCF and then unload it. Used to verify the ERCF gear
 # if all is ok, the ERCF is ready to be used
-[gcode_macro HOME_ERCF_ONLY]
+[gcode_macro ERCF_HOME_ONLY]
 gcode:
     {% if printer["gcode_macro PAUSE_ERCF"].is_paused|int == 0 %}
     	M118 Homing selector
@@ -699,7 +699,7 @@ gcode:
     	G4 P500
     	UNLOAD_FILAMENT_FROM_ERCF
     	UNSELECT_TOOL
-    	SET_GCODE_VARIABLE MACRO=HOME_ERCF VARIABLE=home VALUE=1
+        SET_GCODE_VARIABLE MACRO=ERCF_HOME VARIABLE=home VALUE=1
     	M118 Homing ERCF ended ...
     {% else %}
     	M118 Homing ERCF failed, ERCF is paused, run "ERCF_UNLOCK" to unlock it ...


### PR DESCRIPTION
This renames `HOME_ERCF` to `ERCF_HOME` and `HOME_ERCF_ONLY` to `ERCF_HOME_ONLY` for consistency with `ERCF_UNLOCK` and `ERCF_INFO`.