### PR TITLE
Add unlock instruction to all pause checks

### DIFF
--- a/Klipper Macros/ercf_macros.cfg
+++ b/Klipper Macros/ercf_macros.cfg
@@ -293,6 +293,8 @@ gcode:
     		M118 Extruder too cold
     		PAUSE_ERCF
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Try to reinsert the filament into the extruder
@@ -316,6 +318,8 @@ gcode:
         		G90
     	    		QUERY_ENDSTOPS
     		{% endif %}
+        {% else %}
+            M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
    	{% endif %}
     {% endif %}
 
@@ -345,6 +349,8 @@ gcode:
         	M118 Extruder too cold
         	PAUSE_ERCF
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Unload the filament from the nozzle (without RAMMING or tip forming)
@@ -374,6 +380,8 @@ gcode:
         	M118 Extruder too cold
        	 	PAUSE_ERCF
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Retry unload, try correct misalignement of bondtech gear
@@ -389,6 +397,8 @@ gcode:
         		G90
         		G92 E0
     		{% endif %}
+        {% else %}
+            M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     	{% endif %}
     {% endif %}
 
@@ -441,6 +451,8 @@ gcode:
         	M118 Extruder too cold
         	PAUSE_ERCF
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 ############################################
@@ -467,6 +479,8 @@ gcode:
     	{% else %}
         	M118 Cannot load to ERCF, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Try to reinsert the filament into the extruder
@@ -498,6 +512,8 @@ gcode:
     	{% else %}
         	M118 Cannot load to extruder, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Load from ERCF to extruder gear by calling LOAD_FILAMENT_TO_ERCF and next LOAD_FILAMENT_FROM_ERCF_TO_EXTRUDER
@@ -512,6 +528,8 @@ gcode:
     	{% else %}
         	M118 Cannot load to extruder, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Unload filament until the ERCF stops detecting it and then pushes it more to ensure filament is not in the selector anymore (but still in the gears)
@@ -532,6 +550,8 @@ gcode:
     	{% else %}
         	M118 Cannot unload from ERCF, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Unload from extruder gear to the ERCF
@@ -547,6 +567,8 @@ gcode:
     	{% else %}
         	M118 Cannot unload from extruder to ERCF, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Unload from the extruder gear to the ERCF by calling UNLOAD_FILAMENT_FROM_EXTRUDER_TO_ERCF and next UNLOAD_FILAMENT_FROM_ERCF
@@ -567,6 +589,8 @@ gcode:
     	{% else %}
         	M118 Cannot unload from extruder to ERCF, tool not selected !!
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 ############################################
@@ -641,6 +665,8 @@ gcode:
     	{% else %}
         	M118 Filament not in extruder
     	{% endif %}
+    {% else %}
+        M118 ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 # Eject from extruder gear to ERCF
@@ -702,7 +728,7 @@ gcode:
     	SET_GCODE_VARIABLE MACRO=HOME_ERCF VARIABLE=home VALUE=1
     	M118 Homing ERCF ended ...
     {% else %}
-    	M118 Homing ERCF failed, ERCF is paused, run "ERCF_UNLOCK" to unlock it ...
+    	M118 Homing ERCF failed, ERCF is paused, run "ERCF_UNLOCK" to unlock it
     {% endif %}
 
 ###############################################


### PR DESCRIPTION
When the ERCF is locked, it's easy (if you're new at least) to forget to unlock it.  When this happens and you're trying to fix an issue, all the commands silently return with no response.  This changes all of the pause checks to print out a message about running unlock.  This might lead to the unlock message being printed more than once in some cases, but that's probably better than not at all.