### PR TITLE
FIX: fix concatenating string for ERCF_DISPLAY_CALIBRATION

### DIFF
--- a/Klipper_Macros/ercf_macros.cfg
+++ b/Klipper_Macros/ercf_macros.cfg
@@ -42,7 +42,7 @@ filename: /home/pi/klipper_config/ercf_vars.cfg
 gcode:
 	{% set path = printer.save_variables.variables %}
 	{% for chan in range(printer["gcode_macro VAR_ERCF"].bowden_load_length|length) %}
-		{% set varname = (ercf_calib_ + chan|string) %}
+		{% set varname = ("ercf_calib_" + chan|string) %}
 		M118 Calibration values : {path[varname]}
 	{% endfor %}
 


### PR DESCRIPTION
I dont know much about Jinja2 (yet), but at least on my end, the ERCF_DISPLAY_CALIBRATION macro is throwing an error because it tries to interpret ercf_calib_ as a variable. Should be a string instead.

Error message is:
"!! Error evaluating 'gcode_macro ERCF_DISPLAY_CALIBRATION:gcode': UndefinedError: 'ercf_calib_' is undefined"