### PR TITLE
ercf_software.cfg: parametrized SuperSlicer ERCF_FORM_TIP_STANDALONE

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -512,30 +512,85 @@ gcode:
 # StandAlone cooling moves to extract proper filament tip
 [gcode_macro ERCF_FORM_TIP_STANDALONE]
 description: Generic tip forming macro
+default_parameter_COOLING_TUBE_LENGTH: 15 # Dragon ST: 15, Dragon HF: 10, Mosquito: 20
+default_parameter_COOLING_TUBE_RETRACTION: 35 # Dragon ST: 35, Dragon HF: 30, Mosquito: 38
+default_parameter_INITIAL_COOLING_SPEED: 10
+default_parameter_FINAL_COOLING_SPEED: 50
+default_parameter_COOLING_MOVES: 5
+default_parameter_TOOLCHANGE_TEMP: 0
+default_parameter_USE_SKINNYDIP: 0
+default_parameter_USE_FAST_SKINNYDIP: 1
+default_parameter_SKINNYDIP_DISTANCE: 31 # Dragon ST: 31, Dragon HF: 26, Mosquito: 34
+default_parameter_DIP_INSERTION_SPEED: 33
+default_parameter_DIP_EXTRACTION_SPEED: 70
+default_parameter_MELT_ZONE_PAUSE: 0
+default_parameter_COOLING_ZONE_PAUSE: 0
+default_parameter_UNLOADING_SPEED_START: 199
+default_parameter_UNLOADING_SPEED: 20
 gcode:
     G91
     G92 E0
-    G1 E-9.05 F1200
-    G1 E0.68 F165
-    G1 E0.70 F168
-    G1 E0.73 F177
-    G1 E0.78 F189
-    G1 E0.82 F197
-    G1 E0.84 F204
-    G1 E0.90 F216
-    G1 E0.97 F234
-    G1 E1.02 F246
-    G1 E1.04 F250
-    G1 E-15.00 F6000.0
-    G1 E-24.50 F5400.0
-    G1 E-7.00 F2700.0
-    G1 E-3.50 F1620.0
-    G1 E20.00 F900.0
-    G1 E-13 F500.0
-    G1 E13 F400.0
-    G1 E-11 F500.0
-    G1 E11 F400.0
-    G1 E-2.00 F50.0
+
+    SET_PRESSURE_ADVANCE ADVANCE=0
+    {% set OLD_TEMP = printer.extruder.target %}
+
+    # Ramming with SuperSlicer standard setting
+    G1 E-8.5000 F3000
+    G1 E0.6860 F163
+    G1 E0.7068 F167
+    G1 E0.7484 F179
+    G1 E0.5687 F186
+    G1 E0.2212 F181
+    G1 E0.8211 F197
+    G1 E0.8523 F204
+    G1 E0.8151 F216
+    G1 E0.0891 F216
+    G1 E0.9770 F234
+    G1 E1.0290 F246
+    G1 E0.6147 F249
+    G1 E0.4247 F249
+
+    # set toolchange temperature just prior to filament being extracted from melt zone and wait for set point
+    # (SKINNYDIP--normal mode only)
+    {% if TOOLCHANGE_TEMP|float > 0 and USE_FAST_SKINNYDIP|int == 0 %}
+       M109 S{TOOLCHANGE_TEMP}
+    {% endif %}
+
+    # Retraction
+    {% set TOTAL_RETRACTION_DISTANCE = COOLING_TUBE_RETRACTION|float + COOLING_TUBE_LENGTH|float / 2 - 15 %}
+    G1 E-15 F{1.0 * UNLOADING_SPEED_START|float * 60}
+    G1 E-{0.7 * TOTAL_RETRACTION_DISTANCE} F{1.0 * UNLOADING_SPEED|float * 60}
+    G1 E-{0.2 * TOTAL_RETRACTION_DISTANCE} F{0.5 * UNLOADING_SPEED|float * 60}
+    G1 E-{0.1 * TOTAL_RETRACTION_DISTANCE} F{0.3 * UNLOADING_SPEED|float * 60}
+
+    {% if TOOLCHANGE_TEMP|float > 0 and USE_FAST_SKINNYDIP|int == 1 %}
+       M104 S{TOOLCHANGE_TEMP}
+    {% endif %}
+
+    # Generate Cooling Moves
+    {% set SPEED_INC = (FINAL_COOLING_SPEED|float - INITIAL_COOLING_SPEED|float) / (2 * COOLING_MOVES|float - 1) %}
+    {% for move in range(COOLING_MOVES|int) %}
+      G1 E{COOLING_TUBE_LENGTH} F{(INITIAL_COOLING_SPEED|float + SPEED_INC*move*2) * 60}
+      G1 E-{COOLING_TUBE_LENGTH} F{(INITIAL_COOLING_SPEED|float + SPEED_INC*(move*2+1)) * 60}
+    {% endfor %}
+
+    # wait for extruder to reach toolchange temperature after cooling moves complete (SKINNYDIP--fast mode only)
+    {% if TOOLCHANGE_TEMP|float > 0 and USE_FAST_SKINNYDIP|int == 1 %}
+        M109 S{TOOLCHANGE_TEMP}
+    {% endif %}
+
+    # Generate a skinnydip move
+    {% if USE_SKINNYDIP|int == 1 %}
+      G1 E{SKINNYDIP_DISTANCE} F{DIP_INSERTION_SPEED|float * 60}
+      G4 P{MELT_ZONE_PAUSE}
+      G1 E-{SKINNYDIP_DISTANCE} F{DIP_EXTRACTION_SPEED|float * 60}
+      G4 P{COOLING_ZONE_PAUSE}
+    {% endif %}
+
+    {% if TOOLCHANGE_TEMP|float > 0 %}
+      M104 S{OLD_TEMP}
+    {% endif %}
+
     G92 E0
 
 # Unload from extruder with tip forming sequence

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -512,22 +512,23 @@ gcode:
 # StandAlone cooling moves to extract proper filament tip
 [gcode_macro ERCF_FORM_TIP_STANDALONE]
 description: Generic tip forming macro
-default_parameter_COOLING_TUBE_LENGTH: 15 # Dragon ST: 15, Dragon HF: 10, Mosquito: 20
-default_parameter_COOLING_TUBE_RETRACTION: 35 # Dragon ST: 35, Dragon HF: 30, Mosquito: 38
-default_parameter_INITIAL_COOLING_SPEED: 10
-default_parameter_FINAL_COOLING_SPEED: 50
-default_parameter_COOLING_MOVES: 5
-default_parameter_TOOLCHANGE_TEMP: 0
-default_parameter_USE_SKINNYDIP: 0
-default_parameter_USE_FAST_SKINNYDIP: 1
-default_parameter_SKINNYDIP_DISTANCE: 31 # Dragon ST: 31, Dragon HF: 26, Mosquito: 34
-default_parameter_DIP_INSERTION_SPEED: 33
-default_parameter_DIP_EXTRACTION_SPEED: 70
-default_parameter_MELT_ZONE_PAUSE: 0
-default_parameter_COOLING_ZONE_PAUSE: 0
-default_parameter_UNLOADING_SPEED_START: 199
-default_parameter_UNLOADING_SPEED: 20
 gcode:
+    {% set COOLING_TUBE_LENGTH = params.COOLING_TUBE_LENGTH|default(15) %} # Dragon ST: 15, Dragon HF: 10, Mosquito: 20
+    {% set COOLING_TUBE_RETRACTION = params.COOLING_TUBE_RETRACTION|default(35) %} # Dragon ST: 35, Dragon HF: 30, Mosquito: 38
+    {% set INITIAL_COOLING_SPEED = params.INITIAL_COOLING_SPEED|default(10) %}
+    {% set FINAL_COOLING_SPEED = params.FINAL_COOLING_SPEED|default(50) %}
+    {% set COOLING_MOVES = params.COOLING_MOVES|default(5) %}
+    {% set TOOLCHANGE_TEMP = params.TOOLCHANGE_TEMP|default(0) %}
+    {% set USE_SKINNYDIP = params.USE_SKINNYDIP|default(0) %}
+    {% set USE_FAST_SKINNYDIP = params.USE_FAST_SKINNYDIP|default(1) %}
+    {% set SKINNYDIP_DISTANCE = params.SKINNYDIP_DISTANCE|default(31) %} # Dragon ST: 31, Dragon HF: 26, Mosquito: 34
+    {% set DIP_INSERTION_SPEED = params.DIP_INSERTION_SPEED|default(33) %}
+    {% set DIP_EXTRACTION_SPEED = params.DIP_EXTRACTION_SPEED|default(70) %}
+    {% set MELT_ZONE_PAUSE = params.MELT_ZONE_PAUSE|default(0) %}
+    {% set COOLING_ZONE_PAUSE = params.COOLING_ZONE_PAUSE|default(0) %}
+    {% set UNLOADING_SPEED_START = params.UNLOADING_SPEED_START|default(199) %}
+    {% set UNLOADING_SPEED = params.UNLOADING_SPEED|default(20) %}
+
     G91
     G92 E0
 


### PR DESCRIPTION
For easier tip calibration, taken from https://github.com/supermerill/SuperSlicer/blob/1a483260caf4cd1ab1aaedbce80052d102450e63/src/libslic3r/GCode/WipeTower.cpp#L983.

Note: 
- the final `G1 E{COOLING_TUBE_LENGTH|float / 2 + COOLING_TUBE_RETRACTION|float - PARKING_POS_RETRACTION|float} F2000` was removed because the calling code in ercf does the retraction.
- the final `M104 ${OLD_TEMP}` should likely be a `M109`. But then the final retraction will be delayed. Not sure that would be good.
- the ramming code is static. Of course, in SuperSlicer you have this extrusion speed curve to customize.