### PR TITLE
Update ercf_software.cfg to use configurable accel on gear_stepper manual moves

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -71,6 +71,7 @@ variable_min_temp_extruder: 180                                                 
 variable_extruder_eject_temp: 240                                                           # Temp used during filament ejection (in the ERCF_HOME macro, if a filament is detected in the toolhead)
 variable_timeout_pause: 72000                                                               # Time out used by the ERCF_PAUSE
 variable_disable_heater: 600                                                                # Delay after which the hotend heater is disabled in the ERCF_PAUSE state
+variable_gear_stepper_accel: 0																# The acceleration value applied to the gear stepper on moves, standard is to use 0
 gcode:
 
 [save_variables]
@@ -133,7 +134,7 @@ gcode:
             G91
             G92 E0
             MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL=0 SYNC=0
+            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
             G1 E-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} F1500.0
 
             ERCF_CALIB_UNLOAD
@@ -198,14 +199,14 @@ default_type: command
 description: Engage the ERCF gear
 gcode:
     MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.5 SPEED=25 ACCEL=0 SYNC=0
+    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.5 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
     SET_SERVO SERVO=ercf_servo ANGLE={printer["gcode_macro ERCF_VAR"].servo_down_angle}
     G4 P200
-    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL=0 SYNC=0
+    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
     G4 P100
-    MANUAL_STEPPER STEPPER=gear_stepper MOVE=-0.5 SPEED=25 ACCEL=0 SYNC=0
+    MANUAL_STEPPER STEPPER=gear_stepper MOVE=-0.5 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
     G4 P100
-    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL=0
+    MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int}
     SET_SERVO SERVO=ercf_servo WIDTH=0.0
 
 # Pull the top hat up (disengage the bondtech gears)
@@ -431,7 +432,7 @@ gcode:
             G91
             G92 E0
             MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float + 20.0} SPEED=25 ACCEL=0 SYNC=0
+            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float + 20.0} SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
             G1 E-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float + 20.0} F1500.0
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float - printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float + printer["gcode_macro ERCF_VAR"].unload_modifier|float - 20.0}
@@ -497,7 +498,7 @@ gcode:
             G91
             G92 E0
             MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-        	MANUAL_STEPPER STEPPER=gear_stepper MOVE={printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float - 7} SPEED=25 ACCEL=0 SYNC=0
+        	MANUAL_STEPPER STEPPER=gear_stepper MOVE={printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float - 7} SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
         	G1 E{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float - 7} F1500.0
         	G4 P100
             ERCF_HOME_EXTRUDER TOTAL_LENGTH=30.0 STEP_LENGTH=0.5
@@ -629,7 +630,7 @@ gcode:
                 G91
                 G92 E0
                 MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-                MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL=0 SYNC=0
+                MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
                 G1 E-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} F1500.0
                 M118 Filament removed
             {% else %}
@@ -864,7 +865,7 @@ gcode:
             G91
             G92 E0
             MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
-            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL=0 SYNC=0
+            MANUAL_STEPPER STEPPER=gear_stepper MOVE=-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
             G1 E-{printer["gcode_macro ERCF_VAR"].end_of_bowden_to_sensor|float} F1500.0
 
             {% set ercf_params = printer.save_variables.variables %}

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -841,6 +841,7 @@ gcode:
     {% else %}
         M118 Runout detected !
         {% if printer["gcode_macro ERCF_VAR"].endless_spool_mode|int == 1 %}
+			{% set pre_change_PA = printer.extruder.pressure_advance %}
             {% if printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|int >= (printer["gcode_macro ERCF_VAR"].colorselector|length -1) %}
                 {% set nexttool = 0 %}
             {% else %}
@@ -874,6 +875,7 @@ gcode:
             ERCF_UNSELECT_TOOL
 
             ERCF_LOAD_TOOL TOOL={nexttool|int}
+			SET_PRESSURE_ADVANCE ADVANCE={pre_change_PA}
             ERCF_CHECK_IF_RESUME
         {% else %}
             M118 EndlessSpool mode not enabled, please do something


### PR DESCRIPTION
Added a configurable option to use acceleration value for use on manual gear stepper moves. Useful if not using the BOM spec motor in the build.