### PR TITLE
Fix filament unloading on flying extruders (with long filament path)

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -424,7 +424,7 @@ gcode:
     {% if printer["gcode_macro ERCF_PAUSE"].is_paused|int == 0 %}
         {% if printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|int != -1 %}
             M118 Unload tool {printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|int} ...
-            ERCF_HOME_EXTRUDER
+            ERCF_HOME_EXTRUDER TOTAL_LENGTH={printer["gcode_macro ERCF_VAR"].sensor_to_nozzle * 2}
             ERCF_SELECT_TOOL TOOL={printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|int}
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|string)]}
@@ -624,7 +624,7 @@ gcode:
                 ERCF_FORM_TIP_STANDALONE
                 G1 E-4.00 F1200.0
                 G1 E-15.00 F2000
-                ERCF_HOME_EXTRUDER
+                ERCF_HOME_EXTRUDER TOTAL_LENGTH={printer["gcode_macro ERCF_VAR"].sensor_to_nozzle * 2} STEP_LENGTH=2.0
                 ERCF_SERVO_DOWN
                 G91
                 G92 E0


### PR DESCRIPTION
Add `TOTAL_LENGTH={printer["gcode_macro ERCF_VAR"].sensor_to_nozzle *
2}` argument to `ERCF_HOME_EXTRUDER` calls in unloading macros to fix
filament unloading on extruders with long filament path, like a flying
extruder on a delta printer.

This fix can also be done in python code by using `sensor_to_nozzle*2`
as a default total length.