### PR TITLE
fix: use set/get_rotation distance for newer klipper versions 

### DIFF
--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -391,7 +391,13 @@ class Ercf:
     def cmd_ERCF_SET_STEPS(self, gcmd):
         ratio = gcmd.get_float('RATIO', 1., above=0.)
         new_step_dist = self.ref_step_dist / ratio
-        self.gear_stepper.rail.steppers[0].set_step_dist(new_step_dist)
+        stepper = self.gear_stepper.rail.steppers[0]
+        if hasattr(stepper, "set_rotation_distance"):
+            new_rotation_dist = new_step_dist * stepper.get_rotation_distance()[1]
+            stepper.set_rotation_distance(new_rotation_dist)
+        else:
+            # bw compatibilty for old klipper versions
+            stepper.set_step_dist(new_step_dist)
 
     cmd_ERCF_GET_SELECTOR_POS_help = "Report the selector motor position"
     def cmd_ERCF_GET_SELECTOR_POS(self, gcmd):


### PR DESCRIPTION
set_step_dist was removed in  https://github.com/Klipper3d/klipper/commit/189188e3ca3e40d8272fb4ad48316e329f8ec453 so use set_rotation_distance for newer versions.