### PR TITLE
use initial_extruder from slicer to home ercf

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -357,7 +357,7 @@ gcode:
     SET_FILAMENT_SENSOR SENSOR=encoder_sensor ENABLE=0
     {% if printer["gcode_macro ERCF_HOME"].home == -1 %}
         M118 ERCF not homed, homing it...
-        ERCF_HOME
+        ERCF_HOME TOOL={params.TOOL|int}
         M117 Change Tool T{params.TOOL|int}
         ERCF_LOAD_TOOL TOOL={params.TOOL|int}
     {% elif printer["gcode_macro ERCF_SELECT_TOOL"].color_selected|int != params.TOOL|int %}
@@ -724,7 +724,7 @@ gcode:
     QUERY_ENDSTOPS
     ERCF_EJECT_UNKNOW_STATE
     ERCF_HOME_SELECTOR
-    ERCF_HOME_ONLY
+    ERCF_HOME_ONLY TOOL={params.TOOL|default(0)|int}
 
 [gcode_macro ERCF_HOME_SELECTOR]
 description: Home the ERCF selector
@@ -752,7 +752,7 @@ gcode:
 gcode:
     {% if printer["gcode_macro ERCF_PAUSE"].is_paused|int == 0 %}
         M118 Test load filament 1
-        ERCF_SELECT_TOOL TOOL=0
+        ERCF_SELECT_TOOL TOOL={params.TOOL|default(0)|int}
         ERCF_SET_STEPS RATIO=1.0
         M118 Loading filament to ERCF...
         ERCF_LOAD LENGTH=45


### PR DESCRIPTION
A TOOL parameter is added to macros ERCF_HOME and ERCF_HOME_ONLY (defaults to 0). This tool is now used to verify the ERCF gear. Useful if you don't use tool 0 in a print and don't have filament loaded to it.