### PR TITLE
servo DWELL advanced variable / fix HOME message 

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -753,7 +753,7 @@ gcode:
 [gcode_macro ERCF_HOME_ONLY]
 gcode:
     {% if printer["gcode_macro ERCF_PAUSE"].is_paused|int == 0 %}
-        M118 Test load filament 1
+        M118 Test load filament {params.TOOL|default(0)|int}
         ERCF_SELECT_TOOL TOOL={params.TOOL|default(0)|int}
         ERCF_SET_STEPS RATIO=1.0
         M118 Loading filament to ERCF...

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -72,6 +72,8 @@ variable_extruder_eject_temp: 240                                               
 variable_timeout_pause: 72000                                                               # Time out used by the ERCF_PAUSE
 variable_disable_heater: 600                                                                # Delay after which the hotend heater is disabled in the ERCF_PAUSE state
 variable_gear_stepper_accel: 0																# The acceleration value applied to the gear stepper on moves, standard is to use 0
+variable_extra_servo_dwell_up: 0                                                            # Additional dwell time in ms to apply to dwell prior to turning off the servo
+variable_extra_servo_dwell_down: 0                                                          # Additional dwell time in ms to apply to dwell prior to turning off the servo
 gcode:
 
 [save_variables]
@@ -205,7 +207,7 @@ gcode:
     MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
     G4 P100
     MANUAL_STEPPER STEPPER=gear_stepper MOVE=-0.5 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int} SYNC=0
-    G4 P100
+    G4 P{100 + printer["gcode_macro ERCF_VAR"].extra_servo_dwell_down|int}
     MANUAL_STEPPER STEPPER=gear_stepper MOVE=0.0 SPEED=25 ACCEL={printer["gcode_macro ERCF_VAR"].gear_stepper_accel|int}
     SET_SERVO SERVO=ercf_servo WIDTH=0.0
 
@@ -214,7 +216,7 @@ gcode:
 description: Disengage the ERCF gear
 gcode:
     SET_SERVO SERVO=ercf_servo ANGLE={printer["gcode_macro ERCF_VAR"].servo_up_angle}
-    G4 P250
+    G4 P{250 + printer["gcode_macro ERCF_VAR"].extra_servo_dwell_up|int}
     SET_SERVO SERVO=ercf_servo WIDTH=0.0
 
 ###############################
@@ -786,7 +788,7 @@ gcode:
 description: Test the servo angle
 gcode:
     SET_SERVO SERVO=ercf_servo ANGLE={params.VALUE|float}
-    G4 P250
+    G4 P{250 + printer["gcode_macro ERCF_VAR"].extra_servo_dwell_up|int}
     SET_SERVO SERVO=ercf_servo WIDTH=0.0
 
 [gcode_macro ERCF_TEST_GRIP]


### PR DESCRIPTION
Added two variables to allow adjustment of dwell time for ERCF_SERVO_UP and ERCF_SERVO_DOWN commands

Also fixed message in ERCD_HOME_ONLY to show actual tool being test loaded instead of 1, which was also incorrect as tool 0 is the default. 