### PR TITLE
Read total length from .end_of_bowden_to_sensor when loading to nozzle

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -554,7 +554,7 @@ gcode:
             MANUAL_STEPPER STEPPER=gear_stepper MOVE={printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float - 7} SPEED=25 ACCEL={printer["gcode_macro _ERCF_VAR"].gear_stepper_accel|int} SYNC=0
             G1 E{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float - 7} F1500.0
             G4 P100
-            ERCF_HOME_EXTRUDER TOTAL_LENGTH=30.0 STEP_LENGTH=0.5
+            ERCF_HOME_EXTRUDER TOTAL_LENGTH={printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float - 7} STEP_LENGTH=0.5
             _ERCF_UNSELECT_TOOL FORCED=0
             ERCF_FINALIZE_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].sensor_to_nozzle|float}
             G92 E0


### PR DESCRIPTION
Had an issue ( #82 ) where ERCF would fault when loading filament from reverse bowden to the toolhead sensor, but shortly after would say "Filament loaded successfully". Thought this might have been a timing issue initially, but I was able to add the end_of_bowden_to_sensor variable to the load length and this stopped the fault from happening.