### PR TITLE
Reduce MCU scheduling/TX pressure for encoder

### DIFF
--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -61,8 +61,8 @@ class Ercf:
         self.encoder_pin = config.get('encoder_pin')
         self.encoder_resolution = config.getfloat('encoder_resolution', 1.5,
                                             above=0.)
-        self._counter = EncoderCounter(self.printer, self.encoder_pin, 0.01,
-                                            0.00001, self.encoder_resolution)
+        self._counter = EncoderCounter(self.printer, self.encoder_pin, 0.1,
+                                            0.0001, self.encoder_resolution)
         
         # Parameters
         self.long_moves_speed = config.getfloat('long_moves_speed', 100.)

--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -61,8 +61,14 @@ class Ercf:
         self.encoder_pin = config.get('encoder_pin')
         self.encoder_resolution = config.getfloat('encoder_resolution', 1.5,
                                             above=0.)
-        self._counter = EncoderCounter(self.printer, self.encoder_pin, 0.1,
-                                            0.0001, self.encoder_resolution)
+        self.encoder_sample_time = config.getfloat('encoder_sample_time', 0.1,
+                                            above=0.)
+        self.encoder_poll_time = config.getfloat('encoder_poll_time', 0.0001,
+                                            above=0.)
+        self._counter = EncoderCounter(self.printer, self.encoder_pin, 
+                                            self.encoder_sample_time,
+                                            self.encoder_poll_time, 
+                                            self.encoder_resolution)
         
         # Parameters
         self.long_moves_speed = config.getfloat('long_moves_speed', 100.)


### PR DESCRIPTION
When investigating another issue I noticed that the MCU TX buffer was spamming a large number of messages for the encoder value back to the HOST, and the vast majority of those messages were unchanged states.

In Klipper, the encoder state always sends messages back to the host at the sample time, even when the state hasn't changed. Using a 0.01 delay adds a lot of data, and might cause other messages to become less responsive if the buffer stalls (like the filament switch if used on the same MCU). I propose reducing the sample delay from 10ms  to 100ms in this change.

Additionally the poll frequency was really high at 10us causing a lot of wake times on the MCU scheduler. I propose also changing this from 10us to 100us. Even at this rate I suspect it's far more than needed, testing load/unload at 400mm/sec I've found no change in the encoder results.

Edit: While printing, I'm finding that this change leads to a large drop in MCU load. With the seeeduino xiao, filament LOAD/UNLOAD would typically be about 50% MCU load with my configuration, after this change it's only 20%.