### PR TITLE
Fixes for _ERCF_UNLOAD_TOOL process

### DIFF
--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -332,6 +332,13 @@ class Ercf:
         unknown_state = gcmd.get_int('UNKNOWN', 0, minval=0, maxval=1)
         req_length = gcmd.get_float('LENGTH', 1200.)
         self.toolhead.wait_moves()
+        # Do not unload if filament is still in the toolhead
+        sensor = self.printer.lookup_object(
+                    "filament_switch_sensor toolhead_sensor")
+        if bool(sensor.runout_helper.filament_present):
+            self.gcode.respond_info(
+                "Unable to unload filament while still in extruder")
+            return
         # i.e. long move that will be fast and iterated using the encoder
         if req_length > self.LONG_MOVE_THRESHOLD: 
             req_length = req_length - buffer_length

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -470,7 +470,7 @@ gcode:
         G1 E-5.00 F1200.0
         G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 25.0} F2000
         _ERCF_SERVO_DOWN
-        G4 P1000
+        G4 P100
         _ERCF_RETRY_EXTRACT_FROM_EXTRUDER
     {% else %}
         G91

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -447,11 +447,11 @@ gcode:
             M118 Unload tool {printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|int} ...
             G1 E-10.00 F1200.0
             G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 20.0} F2000
+            G4 P100
+            _ERCF_EXTRACT_FROM_EXTRUDER
             _ERCF_SELECT_TOOL TOOL={printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|int}
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|string)]}
-            G4 P100
-            _ERCF_EXTRACT_FROM_EXTRUDER
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
             _ERCF_UNSELECT_TOOL
@@ -466,10 +466,8 @@ description: Extract the tip at the parking position from the extruder
 gcode:
     {% if printer['filament_switch_sensor toolhead_sensor'].filament_detected == True %}
         M118 Filament still below the extruder... Trying extraction again...
-        _ERCF_SERVO_UP
         G1 E-5.00 F1200.0
         G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 25.0} F2000
-        _ERCF_SERVO_DOWN
         G4 P100
         _ERCF_RETRY_EXTRACT_FROM_EXTRUDER
     {% else %}

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -452,8 +452,6 @@ gcode:
             ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|string)]}
             G4 P100
             _ERCF_EXTRACT_FROM_EXTRUDER
-            {% set ercf_params = printer.save_variables.variables %}
-            ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
             _ERCF_UNSELECT_TOOL
         {% endif %}
     {% else %}
@@ -480,6 +478,8 @@ gcode:
         MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
         MANUAL_STEPPER STEPPER=gear_stepper MOVE=-10 SPEED=25 ACCEL=0 SYNC=0
         G1 E10 F2000.0
+        {% set ercf_params = printer.save_variables.variables %}
+        ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
     {% endif %}
 
 # Unload filament from nozzle to ERCF, using SuperSlicer ramming
@@ -498,6 +498,8 @@ gcode:
         MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
         MANUAL_STEPPER STEPPER=gear_stepper MOVE=-10 SPEED=25 ACCEL=0 SYNC=0
         G1 E10 F2000.0
+        {% set ercf_params = printer.save_variables.variables %}
+        ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
     {% endif %}
 
 

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -573,6 +573,7 @@ gcode:
             MANUAL_STEPPER STEPPER=gear_stepper MOVE={printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float - 7} SPEED=25 ACCEL={printer["gcode_macro _ERCF_VAR"].gear_stepper_accel|int} SYNC=0
             G1 E{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float - 7} F1500.0
             G4 P100
+            M400
             ERCF_HOME_EXTRUDER TOTAL_LENGTH=30.0 STEP_LENGTH=0.5
             _ERCF_UNSELECT_TOOL FORCED=0
             ERCF_FINALIZE_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].sensor_to_nozzle|float} THRESHOLD={printer["gcode_macro _ERCF_VAR"].final_load_check_threshold|float} TUNE={tune}

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -466,9 +466,11 @@ description: Extract the tip at the parking position from the extruder
 gcode:
     {% if printer['filament_switch_sensor toolhead_sensor'].filament_detected == True %}
         M118 Filament still below the extruder... Trying extraction again...
+        _ERCF_SERVO_UP
         G1 E-5.00 F1200.0
         G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 25.0} F2000
-        G4 P100
+        _ERCF_SERVO_DOWN
+        G4 P1000
         _ERCF_RETRY_EXTRACT_FROM_EXTRUDER
     {% else %}
         G91

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -453,6 +453,8 @@ gcode:
             G4 P100
             M400
             _ERCF_EXTRACT_FROM_EXTRUDER
+            {% set ercf_params = printer.save_variables.variables %}
+            ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
             _ERCF_UNSELECT_TOOL
         {% endif %}
     {% else %}
@@ -480,8 +482,6 @@ gcode:
         MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
         MANUAL_STEPPER STEPPER=gear_stepper MOVE=-10 SPEED=25 ACCEL=0 SYNC=0
         G1 E10 F2000.0
-        {% set ercf_params = printer.save_variables.variables %}
-        ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
     {% endif %}
 
 # Unload filament from nozzle to ERCF, using SuperSlicer ramming
@@ -500,8 +500,6 @@ gcode:
         MANUAL_STEPPER STEPPER=gear_stepper SET_POSITION=0
         MANUAL_STEPPER STEPPER=gear_stepper MOVE=-10 SPEED=25 ACCEL=0 SYNC=0
         G1 E10 F2000.0
-        {% set ercf_params = printer.save_variables.variables %}
-        ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
     {% endif %}
 
 

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -447,11 +447,11 @@ gcode:
             M118 Unload tool {printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|int} ...
             G1 E-10.00 F1200.0
             G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 20.0} F2000
-            G4 P100
-            _ERCF_EXTRACT_FROM_EXTRUDER
             _ERCF_SELECT_TOOL TOOL={printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|int}
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|string)]}
+            G4 P100
+            _ERCF_EXTRACT_FROM_EXTRUDER
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
             _ERCF_UNSELECT_TOOL
@@ -466,8 +466,10 @@ description: Extract the tip at the parking position from the extruder
 gcode:
     {% if printer['filament_switch_sensor toolhead_sensor'].filament_detected == True %}
         M118 Filament still below the extruder... Trying extraction again...
+        _ERCF_SERVO_UP
         G1 E-5.00 F1200.0
         G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 25.0} F2000
+        _ERCF_SERVO_DOWN
         G4 P100
         _ERCF_RETRY_EXTRACT_FROM_EXTRUDER
     {% else %}

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -451,6 +451,7 @@ gcode:
             {% set ercf_params = printer.save_variables.variables %}
             ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|string)]}
             G4 P100
+            M400
             _ERCF_EXTRACT_FROM_EXTRUDER
             _ERCF_UNSELECT_TOOL
         {% endif %}
@@ -469,6 +470,7 @@ gcode:
         G1 E-{printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 25.0} F2000
         _ERCF_SERVO_DOWN
         G4 P100
+        M400
         _ERCF_RETRY_EXTRACT_FROM_EXTRUDER
     {% else %}
         G91


### PR DESCRIPTION
Sporadically I have issues where filament extraction fails from time to time, and reports that the filament is stuck below the extruder, however when watching the state of the filament sensor I can see very clearly that the tool head sensor is empty before the extraction retry starts.

This change will bring in 3 fixes to help address this (and related) problems:

* The selector servo is now lifted for the retry. Previously it was left in place as the retry happens after SELECT_TOOL.
* ERCF_UNLOAD has been moved such that it isn't called if the filament is stuck, this would grind the filament otherwise.
* The sporadic error reporting that filament was stuck is fixed by adding M400 before checking the filament sensor status (explanation below).

The primary reason for the error has to do with a subtlety in the use of the `G4 P100` delay. If you look at **toolhead.py** you will notice that the `dwell()` function only advances `print_time` which causes the scheduling of MCU commands to be adjusted. In practice this leads to a delay since the MCU will sleep until the next schedule command time. It doesn't always lead to a delay before the next gcode line is processed and added to the MCU command buffer though. This means that the filament extraction may not have completed by the time we check the status of the filament sensor since this check isn't placed on the MCU command buffer, but rather executed immediately from the host's saved state.

M400 solves the problem by actually stalling the gcode processing until the MCU execution time catches up with the scheduled `print_time`. So when inserting delays for non MCU scheduled events it's necessary to use both `G4` and `M400` in sequence to have the intended effect.

FIXES #82, #90