### PR TITLE
Note as un-homed after _ERCF_MOTORS_OFF

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -236,6 +236,7 @@ description: Turn off both ERCF motors
 gcode:
     MANUAL_STEPPER STEPPER=gear_stepper ENABLE=0
     MANUAL_STEPPER STEPPER=selector_stepper ENABLE=0
+    SET_GCODE_VARIABLE MACRO=ERCF_HOME VARIABLE=home VALUE=-1
 
 ###############################
 # PAUSE MACROS


### PR DESCRIPTION
As I'm tuning things, I find that I often want to pull a filament out to check the tip or to push a filament in against the gate to verify that it hasn't slipped. But if that filament was the most recently selected one (which is the most common scenario), the presence of the selector makes that difficult. (It doesn't impede removal, just reinsertion.)

So, I added _ERCF_MOTORS_OFF to the end of my FINISH_PRINT macro so that I can slide the selector out of the way. But I notice that it doesn't currently reset the "I've been homed" flag used elsewhere in the ERCF code. This PR fixes that. 