### PR TITLE
Add number of moves for load/unload

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -79,6 +79,7 @@ variable_disable_heater: 600                                                    
 variable_gear_stepper_accel: 0                                                              # The acceleration value applied to the gear stepper on moves, standard is to use 0
 variable_extra_servo_dwell_up: 0                                                            # Additional dwell time in ms to apply to dwell prior to turning off the servo
 variable_extra_servo_dwell_down: 0                                                          # Additional dwell time in ms to apply to dwell prior to turning off the servo
+variable_num_moves: 1                                                                       # Nunber of moves to use for load/unload. Increase to 2 or 3 to prevent 'Timer too close' error
 gcode:
 
 [save_variables]
@@ -133,7 +134,7 @@ gcode:
             {% endif %}
 
             M118 Calibrating reference tool {params.TOOL}
-            ERCF_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length}
+            ERCF_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length} MOVES={printer["gcode_macro _ERCF_VAR"].num_moves}
             ERCF_HOME_EXTRUDER TOTAL_LENGTH=400 STEP_LENGTH=0.5
             
             _ERCF_CALIB_SAVE_VAR TOOL={params.TOOL}
@@ -152,10 +153,10 @@ gcode:
         {% else %}
             M118 Calibrating tool {params.TOOL}
 
-            ERCF_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length|float - 100.0}
+            ERCF_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length|float - 100.0} MOVES={printer["gcode_macro _ERCF_VAR"].num_moves}
             _ERCF_CALIB_SAVE_VAR tool={params.TOOL}
 
-            _ERCF_CALIB_UNLOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length|float - 100.0 + 27.0}
+            _ERCF_CALIB_UNLOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length|float - 100.0 + 27.0} MOVES={printer["gcode_macro _ERCF_VAR"].num_moves}
         {% endif %}
 
     {% else %}
@@ -740,7 +741,7 @@ gcode:
             M109 S{printer["gcode_macro _ERCF_VAR"].extruder_eject_temp}
         {% endif %}
         _ERCF_UNLOAD_FILAMENT_IN_EXTRUDER_WITH_TIP_FORMING
-        ERCF_UNLOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length - 50} UNKNOWN=1
+        ERCF_UNLOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length - 50} UNKNOWN=1 MOVES={printer["gcode_macro _ERCF_VAR"].num_moves}
     {% else %}
         _ERCF_SERVO_DOWN
         ERCF_BUZZ_GEAR_MOTOR


### PR DESCRIPTION
Add a variable which breaks ERCF_LOAD and ERCF_UNLOAD into a number of moves, this reduces lag on the step planner and works around the 'Timer too close' error that some people get during long moves on the gear stepper.

The nice thing about this change is that you cannot actually tell the moves were broken up, since the motion planner in klipper sees the the target velocity is the same (junction deviation is nil) it won't decelerate/accelerate so you get the benefit  of the workaround without any down-sides.

This should fix issues #107 and #75