### PR TITLE
maintain clog_detection if slicer change to same tool

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -358,8 +358,8 @@ gcode:
         # M118 Swap {newcounter|int}
         _ERCF_UNLOAD_TOOL
         _ERCF_LOAD_TOOL TOOL={params.TOOL|int}
-        _ERCF_CHANGE_TOOL_SLICER_END
     {% endif %}
+    _ERCF_CHANGE_TOOL_SLICER_END
     
 [gcode_macro _ERCF_CHANGE_TOOL_SLICER_END]
 gcode:


### PR DESCRIPTION
Clog detection was being disabled due to superslicer adding a T# after my print_start where I switch to that tool. This would disable the filament sensor, skip the conditional, and leave the filament sensor disabled. This change runs the _ERCF_CHANGE_TOOL_SLICER_END regardless of the conditional, restoring the filament sensor state if the option for clog detection is enabled.