### PR TITLE
Fix the eject length calculation

### DIFF
--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -436,7 +436,8 @@ gcode:
                 _ERCF_UNLOAD_FILAMENT_IN_EXTRUDER_WITH_TIP_FORMING
                 {% set ercf_params = printer.save_variables.variables %}
                 ERCF_SET_STEPS RATIO={ercf_params['ercf_calib_%s' % (printer["gcode_macro _ERCF_SELECT_TOOL"].color_selected|string)]}
-                ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float - 60.0}
+
+                ERCF_UNLOAD LENGTH={ercf_params.ercf_calib_ref|float - printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + printer["gcode_macro _ERCF_VAR"].unload_modifier|float}
                 _ERCF_UNSELECT_TOOL
             {% else %}
                 _ERCF_EJECT_UNKNOW_STATE

--- a/Klipper_Files/ercf_software.cfg
+++ b/Klipper_Files/ercf_software.cfg
@@ -143,7 +143,7 @@ gcode:
 
             M118 Calibrating reference tool {params.TOOL}
             ERCF_LOAD LENGTH={printer["gcode_macro _ERCF_VAR"].min_bowden_length} MOVES={printer["gcode_macro _ERCF_VAR"].num_moves}
-            ERCF_HOME_EXTRUDER TOTAL_LENGTH=400 STEP_LENGTH=0.5
+            ERCF_HOME_EXTRUDER TOTAL_LENGTH={printer["gcode_macro _ERCF_VAR"].end_of_bowden_to_sensor|float + 400} STEP_LENGTH=0.5
             
             _ERCF_CALIB_SAVE_VAR TOOL={params.TOOL}
 


### PR DESCRIPTION
The same code has already been deployed under the macro `_ERCF_CLOG_OR_RUNOUT`. This ensures the correct calibration for the second stage of the ERCF_UNLOAD from the extruder to the ERCF selector. 