### PR TITLE
synchronize the acceleration between the gear stepper and the extruder

### DIFF
--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -243,8 +243,8 @@ class Ercf:
                     break
                 if both_in_sync :
                     self.gear_stepper.do_set_position(0.)
-                    self.gear_stepper.do_move(step_length, homing_speed, 
-                                                self.short_moves_accel, False)
+                    self.gear_stepper.do_move(step_length, homing_speed,
+                                              self.toolhead.max_accel, False)
                 pos = self.toolhead.get_position()
                 pos[3] += step_length
                 self.toolhead.manual_move(pos, homing_speed)


### PR DESCRIPTION
Discussed under https://github.com/EtteGit/EnragedRabbitProject/issues/131

The "timer too close" is still under investigation. However synchronizing the toolhead extruder and the gear stepper is a quality-of-life improvement making sure two steppers are moving together. 