### PR TITLE
Use Stallguard to detect the filament hitting the extruder

### DIFF
--- a/Klipper_Files/ercf_hardware.cfg
+++ b/Klipper_Files/ercf_hardware.cfg
@@ -3,6 +3,23 @@
 [mcu ercf]
 serial: /dev/serial/by-id/usb-Klipper_samd21g18a_F6EE357D3432585020312E3545150FFF-if00
 
+[tmc2209 manual_stepper gear_stepper]
+# Adapt accordingly to your setup and desires
+# The default values are tested with the BOM NEMA14 motor
+# Please adapt those values to the motor you are using
+# Example : for NEMA17 motors, you'll usually set the stealthchop_threshold to 0
+# and use higher current
+uart_pin: ercf:PA8
+uart_address: 0
+interpolate: True
+run_current: 0.40
+hold_current: 0.3
+sense_resistor: 0.150
+stealthchop_threshold: 500 
+# Uncomment the lines below if you want to use sensorless homing for the toolhead
+# diag_pin: ^ercf:PA7      # Set to MCU pin connected to TMC DIAG pin
+# driver_SGTHRS: 75        # 255 is most sensitive value, 0 is least sensitive. NEEDS TO BE TUNED.
+
 # Carrot Feeder 5mm D-cut shaft
 # Example for an SKR 1.4 Board (E1 on the XY mcu)
 [manual_stepper gear_stepper]
@@ -17,20 +34,8 @@ velocity: 35
 accel: 150
 #Right now no pin is used for the endstop, but we need to define one for klipper. So just use a random, not used pin
 endstop_pin: ^ercf:PA7
-
-[tmc2209 manual_stepper gear_stepper]
-# Adapt accordingly to your setup and desires
-# The default values are tested with the BOM NEMA14 motor
-# Please adapt those values to the motor you are using
-# Example : for NEMA17 motors, you'll usually set the stealthchop_threshold to 0
-# and use higher current
-uart_pin: ercf:PA8
-uart_address: 0
-interpolate: True
-run_current: 0.40
-hold_current: 0.3
-sense_resistor: 0.150
-stealthchop_threshold: 500 
+# comment the line above and uncomment the line below if using stallguard for homing to the extruder
+# endstop_pin: tmc2209_gear_stepper:virtual_endstop
 
 # Carrot Feeder selector
 # Example for an SKR 1.4 Board (Z1 on the XY mcu)

--- a/Klipper_Files/ercf_parameters.cfg
+++ b/Klipper_Files/ercf_parameters.cfg
@@ -54,6 +54,7 @@ num_moves: 2 # Number of moves to make when loading or unloading
 
 # Features
 sensorless_selector: 0                                                             # 0 = use an endstop, 1 = use sensorless homing
+toolhead_use_stallguard: 0                                                         # 0 = use 'collision' homing, 1 = use stallguard for homing
 enable_clog_detection: 0                                                           # 0 = do not use clog detection, 1 = use clog detection
 enable_endless_spool: 0                                                            # 0 = do not use endless spool, 1 = use endless spool
 # if endless spool is turned on, you must define a list of EndlessSpool groups here, one entry for each tool in your ERCF


### PR DESCRIPTION
Rather than just ramming the filament into the extruder gears, allow people to use stallguard to detect the extruder a little more gently.

This will need documentation in the PDF, as tuning the stallguard threshold is important.