### PR TITLE
Change to remove need for "fake" endstop

### DIFF
--- a/Klipper_Files/Extra module/ercf.py
+++ b/Klipper_Files/Extra module/ercf.py
@@ -227,7 +227,7 @@ class Ercf:
         if self.gear_stepper is None:
             raise config.error(
                 "Manual_stepper gear_stepper must be specified")
-        self.ref_step_dist=self.gear_stepper.rail.steppers[0].get_step_dist()
+        self.ref_step_dist=self.gear_stepper.rail.get_step_dist()
         self.variables = self.printer.lookup_object('save_variables').allVariables
         self.encoder_sensor = self.printer.lookup_object("filament_motion_sensor encoder_sensor")
         self.printer.register_event_handler("klippy:ready", self._setup_heater_off_reactor)
@@ -1093,7 +1093,7 @@ class Ercf:
     def _set_steps(self, ratio=1.):
         self._log_trace("Setting ERCF gear motor step ratio to %.1f" % ratio)
         new_step_dist = self.ref_step_dist / ratio
-        stepper = self.gear_stepper.rail.steppers[0]
+        stepper = self.gear_stepper.rail
         if hasattr(stepper, "set_rotation_distance"):
             new_rotation_dist = new_step_dist * stepper.get_rotation_distance()[1]
             stepper.set_rotation_distance(new_rotation_dist)

--- a/Klipper_Files/ercf_hardware.cfg
+++ b/Klipper_Files/ercf_hardware.cfg
@@ -15,8 +15,6 @@ microsteps: 16  # Please do not go higher than 16, this can cause 'MCU Timer too
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 velocity: 35
 accel: 150
-#Right now no pin is used for the endstop, but we need to define one for klipper. So just use a random, not used pin
-endstop_pin: ^ercf:PA7
 
 [tmc2209 manual_stepper gear_stepper]
 # Adapt accordingly to your setup and desires


### PR DESCRIPTION
Remove the need for the "fake" endstop by changing the internal klipper api used for the gear stepper.